### PR TITLE
[CRITEO] Update build to be able to build it with github actions and to push operator artifact in release

### DIFF
--- a/.github/workflows/criteo.yml
+++ b/.github/workflows/criteo.yml
@@ -1,0 +1,25 @@
+name: Release
+on: release
+jobs:
+
+  build:
+    name: Publish artifacts
+    runs-on: ubuntu-18.04
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.14
+
+      - name: run build
+        run: make -j4 IMAGES='ceph' build
+
+      - run: pwd; ls -l
+
+      - name: upload ghr
+        uses: fnkr/github-action-ghr@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHR_PATH: ./images/ceph/operator.tgz

--- a/Makefile
+++ b/Makefile
@@ -85,9 +85,6 @@ GO_TEST_FILTER=$(TESTFILTER)
 
 include build/makelib/golang.mk
 
-# setup helm charts
-include build/makelib/helm.mk
-
 # ====================================================================================
 # Targets
 
@@ -95,7 +92,7 @@ build.version:
 	@mkdir -p $(OUTPUT_DIR)
 	@echo "$(VERSION)" > $(OUTPUT_DIR)/version
 
-build.common: build.version helm.build mod.check
+build.common: build.version mod.check
 	@$(MAKE) go.init
 	@$(MAKE) go.validate
 

--- a/images/ceph/Makefile
+++ b/images/ceph/Makefile
@@ -53,6 +53,8 @@ do.build: generate-csv-ceph-templates
 	else\
 		mkdir $(TEMP)/ceph-csv-templates;\
 	fi
+	@mkdir operator
+	@cp -r $(TEMP)/* operator; tar cvfz operator.tgz operator
 	@cd $(TEMP) && $(SED_CMD) 's|BASEIMAGE|$(BASEIMAGE)|g' Dockerfile
 	@$(DOCKERCMD) build $(BUILD_ARGS) \
 		--build-arg ARCH=$(GOARCH) \


### PR DESCRIPTION
Helm build rely still rely on https://kubernetes-charts.storage.googleapis.com/ which is not anymore available with release 1.3
A commit on 1.4 has been done to not used it but it is a quite big commit with migration to help 3 + some code change that I prefer not to backport to solve this.
As we don't rely on helm here it is more safer to just not build it