### PR TITLE
ceph: Add image pull secrets option on new helm cluster

### DIFF
--- a/cluster/charts/rook-ceph-cluster/templates/serviceaccount.yaml
+++ b/cluster/charts/rook-ceph-cluster/templates/serviceaccount.yaml
@@ -4,14 +4,17 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: rook-ceph-osd
+{{ template "imagePullSecrets" . }}
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: rook-ceph-mgr
+{{ template "imagePullSecrets" . }}
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: rook-ceph-cmd-reporter
+{{ template "imagePullSecrets" . }}
 {{- end }}

--- a/cluster/charts/rook-ceph-cluster/values.yaml
+++ b/cluster/charts/rook-ceph-cluster/values.yaml
@@ -29,6 +29,10 @@ monitoring:
   enabled: false
   rulesNamespaceOverride:
 
+# imagePullSecrets option allow to pull docker images from private docker registry. Option will be passed to all service accounts.
+# imagePullSecrets:
+# - name: my-registry-secret
+
 # All values below are taken from the CephCluster CRD
 # More information can be found at [Ceph Cluster CRD](/Documentation/ceph-cluster-crd.md)
 cephClusterSpec:


### PR DESCRIPTION
Allow to specify imagePullSecrets to pull operator/ceph images from private registry

Based on PR: https://github.com/rook/rook/pull/8296