### PR TITLE
Define RBAC for ceph osd purge job so it can run on non operator namespace

### DIFF
--- a/cluster/charts/rook-ceph-cluster/templates/role.yaml
+++ b/cluster/charts/rook-ceph-cluster/templates/role.yaml
@@ -65,6 +65,24 @@ rules:
       - create
       - update
       - delete
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rook-ceph-purge-osd
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "delete" ]
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["get", "list", "delete" ]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["delete"]
 
 {{- if .Values.monitoring.enabled }}
 ---

--- a/cluster/charts/rook-ceph-cluster/templates/rolebinding.yaml
+++ b/cluster/charts/rook-ceph-cluster/templates/rolebinding.yaml
@@ -67,6 +67,20 @@ subjects:
   - kind: ServiceAccount
     name: rook-ceph-cmd-reporter
     namespace: {{ .Release.Namespace }}
+---
+# Allow the osd purge job to run in this namespace
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rook-ceph-purge-osd
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rook-ceph-purge-osd
+subjects:
+  - kind: ServiceAccount
+    name: rook-ceph-purge-osd
+    namespace: {{ .Release.Namespace }}
 
 {{- if .Values.monitoring.enabled }}
 ---

--- a/cluster/charts/rook-ceph-cluster/templates/serviceaccount.yaml
+++ b/cluster/charts/rook-ceph-cluster/templates/serviceaccount.yaml
@@ -17,4 +17,10 @@ kind: ServiceAccount
 metadata:
   name: rook-ceph-cmd-reporter
 {{ template "imagePullSecrets" . }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rook-ceph-purge-osd
+{{ template "imagePullSecrets" . }}
 {{- end }}

--- a/cluster/charts/rook-ceph/templates/role.yaml
+++ b/cluster/charts/rook-ceph/templates/role.yaml
@@ -157,4 +157,23 @@ rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["get", "watch", "list", "delete", "update", "create"]
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rook-ceph-purge-osd
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "delete" ]
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["get", "list", "delete" ]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["delete"]
+
 {{- end }}

--- a/cluster/charts/rook-ceph/templates/rolebinding.yaml
+++ b/cluster/charts/rook-ceph/templates/rolebinding.yaml
@@ -118,4 +118,17 @@ roleRef:
   kind: Role
   name: rbd-external-provisioner-cfg
   apiGroup: rbac.authorization.k8s.io
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rook-ceph-purge-osd
+subjects:
+  - kind: ServiceAccount
+    name: rook-ceph-purge-osd
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: rook-ceph-purge-osd
+  apiGroup: rbac.authorization.k8s.io
 {{- end }}

--- a/cluster/charts/rook-ceph/templates/serviceaccount.yaml
+++ b/cluster/charts/rook-ceph/templates/serviceaccount.yaml
@@ -83,3 +83,11 @@ metadata:
   name: rook-ceph-admission-controller
   namespace: {{  .Release.Namespace }}
 ---
+# Service account for the purge osd job
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rook-ceph-purge-osd
+  namespace: {{ .Release.Namespace }}
+{{ template "imagePullSecrets" . }}
+---

--- a/cluster/examples/kubernetes/ceph/common-second-cluster.yaml
+++ b/cluster/examples/kubernetes/ceph/common-second-cluster.yaml
@@ -126,3 +126,44 @@ kind: ServiceAccount
 metadata:
   name: rook-ceph-osd
   namespace: $NAMESPACE
+---
+# Aspects of ceph osd purge job that require access to the operator/cluster namespace
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rook-ceph-purge-osd
+  namespace: $NAMESPACE
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "delete"]
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["get", "list", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["delete"]
+---
+# Allow the osd purge job to run in this namespace
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rook-ceph-purge-osd
+  namespace: $NAMESPACE
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rook-ceph-purge-osd
+subjects:
+  - kind: ServiceAccount
+    name: rook-ceph-purge-osd
+    namespace: $NAMESPACE
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rook-ceph-purge-osd
+  namespace: $NAMESPACE

--- a/cluster/examples/kubernetes/ceph/common.yaml
+++ b/cluster/examples/kubernetes/ceph/common.yaml
@@ -1149,3 +1149,44 @@ roleRef:
   name: rbd-external-provisioner-runner
   apiGroup: rbac.authorization.k8s.io
 # OLM: END CSI RBD CLUSTER ROLEBINDING
+---
+# Aspects of ceph osd purge job that require access to the operator/cluster namespace
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rook-ceph-purge-osd
+  namespace: rook-ceph # namespace:operator
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "delete"]
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["get", "list", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["delete"]
+---
+# Allow the osd purge job to run in this namespace
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rook-ceph-purge-osd
+  namespace: rook-ceph # namespace:operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rook-ceph-purge-osd
+subjects:
+  - kind: ServiceAccount
+    name: rook-ceph-purge-osd
+    namespace: rook-ceph # namespace:operator
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rook-ceph-purge-osd
+  namespace: rook-ceph # namespace:operator

--- a/cluster/examples/kubernetes/ceph/osd-purge.yaml
+++ b/cluster/examples/kubernetes/ceph/osd-purge.yaml
@@ -22,7 +22,7 @@ metadata:
 spec:
   template:
     spec:
-      serviceAccountName: rook-ceph-system
+      serviceAccountName: rook-ceph-purge-osd
       containers:
         - name: osd-removal
           image: rook/ceph:v1.6.7


### PR DESCRIPTION
Currently ceph osd purge job rely on rook-ceph-system service account which is only created on the rook operator namespace
When multiple clusters are deployed on distinct namespace the ceph osd purge failed to run as the service account is not available
Creating a specific service account rook-ceph-purge-osd with appropriate rights on each cluster namespace and operator namespace to still manage case where cluster is installed along side the operator