### PR TITLE
CRITEO - rgw: use insecure TLS

### DIFF
--- a/pkg/operator/ceph/object/health.go
+++ b/pkg/operator/ceph/object/health.go
@@ -18,7 +18,9 @@ package object
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/ceph/go-ceph/rgw/admin"
@@ -169,6 +171,11 @@ func (c *bucketChecker) checkObjectStoreHealth() error {
 	s3client, err := NewS3Agent(s3AccessKey, s3SecretKey, s3endpoint, false, tlsCert)
 	if err != nil {
 		return errors.Wrap(err, "failed to initialize s3 connection")
+	}
+	// Force the s3 client to use insecure TLS connection
+	s3client.Client.Config.HTTPClient.Transport = &http.Transport{
+		// #nosec G402 is enabled only for testing
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 	}
 
 	// Force purge the s3 object before starting anything

--- a/pkg/operator/ceph/object/s3-handlers.go
+++ b/pkg/operator/ceph/object/s3-handlers.go
@@ -207,6 +207,6 @@ func BuildTransportTLS(tlsCert []byte) *http.Transport {
 	caCertPool.AppendCertsFromPEM(tlsCert)
 
 	return &http.Transport{
-		TLSClientConfig: &tls.Config{RootCAs: caCertPool, MinVersion: tls.VersionTLS12},
+		TLSClientConfig: &tls.Config{RootCAs: caCertPool, MinVersion: tls.VersionTLS12, InsecureSkipVerify: true},
 	}
 }


### PR DESCRIPTION
Backport https://github.com/rook/rook/pull/8712
And also apply the patch on user creation

There are currently some discussion on rook community around using insecure TLS.
At our side we should be able to remove this patch once we will have internal PKI.
Currently our certs are limited in term of domains and can't manage the *.namespace.svc ones
