### PR TITLE
Add missing get/update rights on rook-ceph-purge-osd job

### DIFF
--- a/cluster/charts/rook-ceph-cluster/templates/role.yaml
+++ b/cluster/charts/rook-ceph-cluster/templates/role.yaml
@@ -82,7 +82,7 @@ rules:
     verbs: ["get", "list", "delete" ]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
-    verbs: ["delete"]
+    verbs: ["get", "update", "delete"]
 
 {{- if .Values.monitoring.enabled }}
 ---

--- a/cluster/charts/rook-ceph/templates/role.yaml
+++ b/cluster/charts/rook-ceph/templates/role.yaml
@@ -188,5 +188,5 @@ rules:
     verbs: ["get", "list", "delete" ]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
-    verbs: ["delete"]
+    verbs: ["get", "update", "delete"]
 {{- end }}

--- a/cluster/examples/kubernetes/ceph/common-second-cluster.yaml
+++ b/cluster/examples/kubernetes/ceph/common-second-cluster.yaml
@@ -145,7 +145,7 @@ rules:
     verbs: ["get", "list", "delete"]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
-    verbs: ["delete"]
+    verbs: ["get", "update", "delete"]
 ---
 # Allow the osd purge job to run in this namespace
 kind: RoleBinding

--- a/cluster/examples/kubernetes/ceph/common.yaml
+++ b/cluster/examples/kubernetes/ceph/common.yaml
@@ -1232,7 +1232,7 @@ rules:
     verbs: ["get", "list", "delete"]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
-    verbs: ["delete"]
+    verbs: ["get", "update", "delete"]
 ---
 # Allow the osd purge job to run in this namespace
 kind: RoleBinding


### PR DESCRIPTION
Deletion of PVC is not well managed by the job deletion due to those missing rights
Sadly the job doesn't failed and well delete every other components which leads to the feeling everything was fine