### PR TITLE
Authorize unsecure connection for s3 user reconcile

### DIFF
--- a/pkg/operator/ceph/object/rgw.go
+++ b/pkg/operator/ceph/object/rgw.go
@@ -362,7 +362,7 @@ func genObjectStoreHTTPClient(objContext *Context, spec *cephv1.ObjectStoreSpec)
 		if err != nil {
 			return nil, tlsCert, errors.Wrapf(err, "failed to fetch CA cert to establish TLS connection with object store %q", nsName)
 		}
-		insecure := false
+		insecure := true
 		c.Transport = BuildTransportTLS(tlsCert, insecure)
 	}
 	return c, tlsCert, nil


### PR DESCRIPTION
 rgw: use insecure TLS for bucket health check #8712 only solved bucket health check
