### PR TITLE
Add capacity to override MON ports

### DIFF
--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -474,6 +474,12 @@ type MonSpec struct {
 	// AllowMultiplePerNode determines if we can run multiple monitors on the same node (not recommended)
 	// +optional
 	AllowMultiplePerNode bool `json:"allowMultiplePerNode,omitempty"`
+	// Port Ceph mons use to communicate amongst themselves prior to Ceph Nautilus
+	// +optional
+	Msgr1Port int32 `json:"msgr1Port,omitempty"`
+	// Port Ceph mons use for messenger v2 protocol introduced in Ceph Nautilus
+	// +optional
+	Msgr2Port int32 `json:"msgr2Port,omitempty"`
 	// StretchCluster is the stretch cluster specification
 	// +optional
 	StretchCluster *StretchClusterSpec `json:"stretchCluster,omitempty"`

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -475,9 +475,11 @@ type MonSpec struct {
 	// +optional
 	AllowMultiplePerNode bool `json:"allowMultiplePerNode,omitempty"`
 	// Port Ceph mons use to communicate amongst themselves prior to Ceph Nautilus
+	// +kubebuilder:default=6789
 	// +optional
 	Msgr1Port int32 `json:"msgr1Port,omitempty"`
 	// Port Ceph mons use for messenger v2 protocol introduced in Ceph Nautilus
+	// +kubebuilder:default=3300
 	// +optional
 	Msgr2Port int32 `json:"msgr2Port,omitempty"`
 	// StretchCluster is the stretch cluster specification

--- a/pkg/daemon/ceph/agent/flexvolume/controller.go
+++ b/pkg/daemon/ceph/agent/flexvolume/controller.go
@@ -398,7 +398,7 @@ func (c *Controller) GetClientAccessInfo(args []string, clientAccessInfo *Client
 	ctx := context.TODO()
 	// args: 0 ClusterNamespace, 1 PodNamespace, 2 MountUser, 3 MountSecret
 	clusterNamespace := args[0]
-	clusterInfo, _, _, err := mon.LoadClusterInfo(c.context, clusterNamespace)
+	clusterInfo, _, _, err := mon.LoadClusterInfo(c.context, clusterNamespace, nil)
 	if err != nil {
 		return errors.Wrapf(err, "failed to load cluster information from clusters namespace %s", clusterNamespace)
 	}

--- a/pkg/daemon/ceph/agent/flexvolume/manager/ceph/manager.go
+++ b/pkg/daemon/ceph/agent/flexvolume/manager/ceph/manager.go
@@ -229,7 +229,7 @@ func (vm *VolumeManager) isAttached(image, pool, clusterNamespace string) (strin
 }
 
 func getClusterInfo(context *clusterd.Context, clusterNamespace string) (string, string, error) {
-	clusterInfo, _, _, err := mon.LoadClusterInfo(context, clusterNamespace)
+	clusterInfo, _, _, err := mon.LoadClusterInfo(context, clusterNamespace, nil)
 	if err != nil {
 		return "", "", errors.Wrapf(err, "failed to load cluster information from cluster %s", clusterNamespace)
 	}

--- a/pkg/daemon/ceph/agent/flexvolume/manager/ceph/manager_test.go
+++ b/pkg/daemon/ceph/agent/flexvolume/manager/ceph/manager_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 	"time"
 
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
 	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
 	clienttest "github.com/rook/rook/pkg/daemon/ceph/client/test"
@@ -161,8 +162,12 @@ func TestAttach(t *testing.T) {
 			called:   0,
 		},
 	}
+	monSpec := cephv1.MonSpec{
+		Msgr1Port: 6789,
+		Msgr2Port: 3300,
+	}
 	ownerInfo := cephclient.NewMinimumOwnerInfoWithOwnerRef()
-	_, _, _, err = mon.CreateOrLoadClusterInfo(context, clusterNamespace, ownerInfo)
+	_, _, _, err = mon.CreateOrLoadClusterInfo(context, clusterNamespace, &monSpec, ownerInfo)
 	assert.NoError(t, err)
 	devicePath, err := vm.Attach("image1", "testpool", "admin", "never-gonna-give-you-up", clusterNamespace)
 	assert.Equal(t, "/dev/rbd3", devicePath)
@@ -243,8 +248,12 @@ func TestDetach(t *testing.T) {
 			called:   0,
 		},
 	}
+	monSpec := cephv1.MonSpec{
+		Msgr1Port: 6789,
+		Msgr2Port: 3300,
+	}
 	ownerInfo := cephclient.NewMinimumOwnerInfoWithOwnerRef()
-	_, _, _, err = mon.CreateOrLoadClusterInfo(context, clusterNamespace, ownerInfo)
+	_, _, _, err = mon.CreateOrLoadClusterInfo(context, clusterNamespace, &monSpec, ownerInfo)
 	assert.NoError(t, err)
 	err = vm.Detach("image1", "testpool", "admin", "", clusterNamespace, false)
 	assert.Nil(t, err)
@@ -299,8 +308,12 @@ func TestDetachCustomKeyring(t *testing.T) {
 			called:   0,
 		},
 	}
+	monSpec := cephv1.MonSpec{
+		Msgr1Port: 6789,
+		Msgr2Port: 3300,
+	}
 	ownerInfo := cephclient.NewMinimumOwnerInfoWithOwnerRef()
-	_, _, _, err = mon.CreateOrLoadClusterInfo(context, clusterNamespace, ownerInfo)
+	_, _, _, err = mon.CreateOrLoadClusterInfo(context, clusterNamespace, &monSpec, ownerInfo)
 	assert.NoError(t, err)
 	err = vm.Detach("image1", "testpool", "user1", "", clusterNamespace, false)
 	assert.Nil(t, err)

--- a/pkg/daemon/ceph/client/config.go
+++ b/pkg/daemon/ceph/client/config.go
@@ -194,7 +194,7 @@ func CreateDefaultCephConfig(context *clusterd.Context, clusterInfo *ClusterInfo
 
 	// extract a list of just the monitor names, which will populate the "mon initial members"
 	// and "mon hosts" global config field
-	monMembers, monHosts := PopulateMonHostMembers(clusterInfo.Monitors)
+	monMembers, monHosts := PopulateMonHostMembers(clusterInfo.Monitors, Msgr2port)
 
 	conf := &CephConfig{
 		GlobalConfig: &GlobalConfig{
@@ -254,7 +254,7 @@ func addClientConfigFileSection(configFile *ini.File, clientName, keyringPath st
 
 // PopulateMonHostMembers extracts a list of just the monitor names, which will populate the "mon initial members"
 // and "mon hosts" global config field
-func PopulateMonHostMembers(monitors map[string]*MonInfo) ([]string, []string) {
+func PopulateMonHostMembers(monitors map[string]*MonInfo, msgr2port int32) ([]string, []string) {
 	monMembers := make([]string, len(monitors))
 	monHosts := make([]string, len(monitors))
 
@@ -268,7 +268,7 @@ func PopulateMonHostMembers(monitors map[string]*MonInfo) ([]string, []string) {
 		// So whatever the previous monitor port was we keep it
 		currentMonPort := cephutil.GetPortFromEndpoint(monitor.Endpoint)
 
-		monPorts := [2]string{strconv.Itoa(int(Msgr2port)), strconv.Itoa(int(currentMonPort))}
+		monPorts := [2]string{strconv.Itoa(int(msgr2port)), strconv.Itoa(int(currentMonPort))}
 		msgr2Endpoint := net.JoinHostPort(monIP, monPorts[0])
 		msgr1Endpoint := net.JoinHostPort(monIP, monPorts[1])
 

--- a/pkg/daemon/ceph/client/config.go
+++ b/pkg/daemon/ceph/client/config.go
@@ -194,7 +194,7 @@ func CreateDefaultCephConfig(context *clusterd.Context, clusterInfo *ClusterInfo
 
 	// extract a list of just the monitor names, which will populate the "mon initial members"
 	// and "mon hosts" global config field
-	monMembers, monHosts := PopulateMonHostMembers(clusterInfo.Monitors, Msgr2port)
+	monMembers, monHosts := PopulateMonHostMembers(clusterInfo)
 
 	conf := &CephConfig{
 		GlobalConfig: &GlobalConfig{
@@ -254,7 +254,8 @@ func addClientConfigFileSection(configFile *ini.File, clientName, keyringPath st
 
 // PopulateMonHostMembers extracts a list of just the monitor names, which will populate the "mon initial members"
 // and "mon hosts" global config field
-func PopulateMonHostMembers(monitors map[string]*MonInfo, msgr2port int32) ([]string, []string) {
+func PopulateMonHostMembers(clusterInfo *ClusterInfo) ([]string, []string) {
+	monitors := clusterInfo.Monitors
 	monMembers := make([]string, len(monitors))
 	monHosts := make([]string, len(monitors))
 
@@ -268,7 +269,7 @@ func PopulateMonHostMembers(monitors map[string]*MonInfo, msgr2port int32) ([]st
 		// So whatever the previous monitor port was we keep it
 		currentMonPort := cephutil.GetPortFromEndpoint(monitor.Endpoint)
 
-		monPorts := [2]string{strconv.Itoa(int(msgr2port)), strconv.Itoa(int(currentMonPort))}
+		monPorts := [2]string{strconv.Itoa(int(clusterInfo.MonSpec.Msgr2Port)), strconv.Itoa(int(currentMonPort))}
 		msgr2Endpoint := net.JoinHostPort(monIP, monPorts[0])
 		msgr1Endpoint := net.JoinHostPort(monIP, monPorts[1])
 

--- a/pkg/daemon/ceph/client/config_test.go
+++ b/pkg/daemon/ceph/client/config_test.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/coreos/pkg/capnslog"
 	"github.com/go-ini/ini"
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
 	cephver "github.com/rook/rook/pkg/operator/ceph/version"
 	"github.com/stretchr/testify/assert"
@@ -46,6 +47,10 @@ func TestCreateDefaultCephConfig(t *testing.T) {
 			"node1": {Name: "mon1", Endpoint: "10.0.0.2:6789"},
 		},
 		CephVersion: cephver.Nautilus,
+		MonSpec: cephv1.MonSpec{
+			Msgr1Port: 6789,
+			Msgr2Port: 3300,
+		},
 	}
 
 	// start with INFO level logging

--- a/pkg/daemon/ceph/client/info.go
+++ b/pkg/daemon/ceph/client/info.go
@@ -46,6 +46,7 @@ type ClusterInfo struct {
 	name              string
 	OsdUpgradeTimeout time.Duration
 	NetworkSpec       cephv1.NetworkSpec
+	MonSpec           cephv1.MonSpec
 }
 
 // MonInfo is a collection of information about a Ceph mon.

--- a/pkg/daemon/ceph/client/test/info.go
+++ b/pkg/daemon/ceph/client/test/info.go
@@ -23,6 +23,7 @@ import (
 	"path"
 
 	"github.com/pkg/errors"
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
 )
 
@@ -53,6 +54,10 @@ func CreateTestClusterInfo(monCount int) *client.ClusterInfo {
 		},
 		Monitors:  map[string]*client.MonInfo{},
 		OwnerInfo: ownerInfo,
+		MonSpec: cephv1.MonSpec{
+			Msgr1Port: 6789,
+			Msgr2Port: 3300,
+		},
 	}
 	mons := []string{"a", "b", "c", "d", "e"}
 	for i := 0; i < monCount; i++ {

--- a/pkg/operator/ceph/client/controller.go
+++ b/pkg/operator/ceph/client/controller.go
@@ -156,7 +156,7 @@ func (r *ReconcileCephClient) reconcile(request reconcile.Request) (reconcile.Re
 	}
 
 	// Make sure a CephCluster is present otherwise do nothing
-	_, isReadyToReconcile, cephClusterExists, reconcileResponse := opcontroller.IsReadyToReconcile(r.client, r.context, request.NamespacedName, controllerName)
+	cephCluster, isReadyToReconcile, cephClusterExists, reconcileResponse := opcontroller.IsReadyToReconcile(r.client, r.context, request.NamespacedName, controllerName)
 	if !isReadyToReconcile {
 		// This handles the case where the Ceph Cluster is gone and we want to delete that CR
 		// We skip the deletePool() function since everything is gone already
@@ -178,7 +178,7 @@ func (r *ReconcileCephClient) reconcile(request reconcile.Request) (reconcile.Re
 	}
 
 	// Populate clusterInfo during each reconcile
-	r.clusterInfo, _, _, err = mon.LoadClusterInfo(r.context, request.NamespacedName.Namespace)
+	r.clusterInfo, _, _, err = mon.LoadClusterInfo(r.context, request.NamespacedName.Namespace, &cephCluster.Spec.Mon)
 	if err != nil {
 		return reconcile.Result{}, errors.Wrap(err, "failed to populate cluster info")
 	}

--- a/pkg/operator/ceph/cluster/cleanup.go
+++ b/pkg/operator/ceph/cluster/cleanup.go
@@ -244,7 +244,7 @@ func (c *ClusterController) getCephHosts(namespace string) ([]string, error) {
 }
 
 func (c *ClusterController) getCleanUpDetails(namespace string) (string, string, error) {
-	clusterInfo, _, _, err := mon.LoadClusterInfo(c.context, namespace)
+	clusterInfo, _, _, err := mon.LoadClusterInfo(c.context, namespace, nil)
 	if err != nil {
 		return "", "", errors.Wrap(err, "failed to get cluster info")
 	}

--- a/pkg/operator/ceph/cluster/cluster.go
+++ b/pkg/operator/ceph/cluster/cluster.go
@@ -179,7 +179,7 @@ func (c *ClusterController) initializeCluster(cluster *cluster) error {
 		}
 	}
 
-	clusterInfo, _, _, err := mon.LoadClusterInfo(c.context, cluster.Namespace)
+	clusterInfo, _, _, err := mon.LoadClusterInfo(c.context, cluster.Namespace, &cluster.Spec.Mon)
 	if err != nil {
 		logger.Infof("clusterInfo not yet found, must be a new cluster")
 	} else {

--- a/pkg/operator/ceph/cluster/cluster_external.go
+++ b/pkg/operator/ceph/cluster/cluster_external.go
@@ -49,7 +49,7 @@ func (c *ClusterController) configureExternalCephCluster(cluster *cluster) error
 	// loop until we find the secret necessary to connect to the external cluster
 	// then populate clusterInfo
 
-	cluster.ClusterInfo = mon.PopulateExternalClusterInfo(c.context, c.namespacedName.Namespace, cluster.ownerInfo)
+	cluster.ClusterInfo = mon.PopulateExternalClusterInfo(c.context, c.namespacedName.Namespace, &cluster.Spec.Mon, cluster.ownerInfo)
 	cluster.ClusterInfo.SetName(c.namespacedName.Name)
 
 	if !client.IsKeyringBase64Encoded(cluster.ClusterInfo.CephCred.Secret) {
@@ -83,7 +83,7 @@ func (c *ClusterController) configureExternalCephCluster(cluster *cluster) error
 		}
 
 		logger.Infof("creating %q secret", config.StoreName)
-		err = config.GetStore(c.context, c.namespacedName.Namespace, cluster.ClusterInfo.OwnerInfo).CreateOrUpdate(cluster.ClusterInfo, cluster.Spec.Mon.Msgr2Port)
+		err = config.GetStore(c.context, c.namespacedName.Namespace, cluster.ClusterInfo.OwnerInfo).CreateOrUpdate(cluster.ClusterInfo)
 		if err != nil {
 			return errors.Wrap(err, "failed to update the global config")
 		}

--- a/pkg/operator/ceph/cluster/cluster_external.go
+++ b/pkg/operator/ceph/cluster/cluster_external.go
@@ -82,13 +82,8 @@ func (c *ClusterController) configureExternalCephCluster(cluster *cluster) error
 			return errors.Wrap(err, "failed to populate config override config map")
 		}
 
-		msgr2Port := int32(3300)
-		if cluster.Spec.Mon.Msgr2Port != 0 {
-			msgr2Port = cluster.Spec.Mon.Msgr2Port
-		}
-
 		logger.Infof("creating %q secret", config.StoreName)
-		err = config.GetStore(c.context, c.namespacedName.Namespace, cluster.ClusterInfo.OwnerInfo).CreateOrUpdate(cluster.ClusterInfo, msgr2Port)
+		err = config.GetStore(c.context, c.namespacedName.Namespace, cluster.ClusterInfo.OwnerInfo).CreateOrUpdate(cluster.ClusterInfo, cluster.Spec.Mon.Msgr2Port)
 		if err != nil {
 			return errors.Wrap(err, "failed to update the global config")
 		}

--- a/pkg/operator/ceph/cluster/cluster_external.go
+++ b/pkg/operator/ceph/cluster/cluster_external.go
@@ -82,8 +82,13 @@ func (c *ClusterController) configureExternalCephCluster(cluster *cluster) error
 			return errors.Wrap(err, "failed to populate config override config map")
 		}
 
+		msgr2Port := int32(3300)
+		if cluster.Spec.Mon.Msgr2Port != 0 {
+			msgr2Port = cluster.Spec.Mon.Msgr2Port
+		}
+
 		logger.Infof("creating %q secret", config.StoreName)
-		err = config.GetStore(c.context, c.namespacedName.Namespace, cluster.ClusterInfo.OwnerInfo).CreateOrUpdate(cluster.ClusterInfo)
+		err = config.GetStore(c.context, c.namespacedName.Namespace, cluster.ClusterInfo.OwnerInfo).CreateOrUpdate(cluster.ClusterInfo, msgr2Port)
 		if err != nil {
 			return errors.Wrap(err, "failed to update the global config")
 		}

--- a/pkg/operator/ceph/cluster/mon/health_test.go
+++ b/pkg/operator/ceph/cluster/mon/health_test.go
@@ -274,7 +274,7 @@ func TestCheckHealthNotFound(t *testing.T) {
 	}
 	ownerInfo := cephclient.NewMinimumOwnerInfoWithOwnerRef()
 	c := New(context, "ns", cephv1.ClusterSpec{}, ownerInfo, &sync.Mutex{})
-	setCommonMonProperties(c, 2, cephv1.MonSpec{Count: 3, AllowMultiplePerNode: true}, "myversion")
+	setCommonMonProperties(c, 2, cephv1.MonSpec{Count: 3, Msgr1Port: 6789, Msgr2Port: 3300, AllowMultiplePerNode: true}, "myversion")
 	c.waitForStart = false
 	defer os.RemoveAll(c.context.ConfigDir)
 

--- a/pkg/operator/ceph/cluster/mon/mon.go
+++ b/pkg/operator/ceph/cluster/mon/mon.go
@@ -544,15 +544,10 @@ func (c *Cluster) clusterInfoToMonConfig(excludedMon string) []*monConfig {
 func (c *Cluster) newMonConfig(monID int, zone string) *monConfig {
 	daemonName := k8sutil.IndexToName(monID)
 
-	msgr1Port := DefaultMsgr1Port
-	if c.spec.Mon.Msgr1Port != 0 {
-		msgr1Port = c.spec.Mon.Msgr1Port
-	}
-
 	return &monConfig{
 		ResourceName: resourceName(daemonName),
 		DaemonName:   daemonName,
-		Port:         msgr1Port,
+		Port:         c.spec.Mon.Msgr1Port,
 		Zone:         zone,
 		DataPathMap: config.NewStatefulDaemonDataPathMap(
 			c.spec.DataDirHostPath, dataDirRelativeHostPath(daemonName), config.MonType, daemonName, c.Namespace),
@@ -1015,14 +1010,9 @@ func (c *Cluster) saveMonConfig() error {
 		return errors.Wrap(err, "failed to persist expected mons")
 	}
 
-	msgr2Port := DefaultMsgr2Port
-	if c.spec.Mon.Msgr2Port != 0 {
-		msgr2Port = c.spec.Mon.Msgr2Port
-	}
-
 	// Every time the mon config is updated, must also update the global config so that all daemons
 	// have the most updated version if they restart.
-	if err := config.GetStore(c.context, c.Namespace, c.ownerInfo).CreateOrUpdate(c.ClusterInfo, msgr2Port); err != nil {
+	if err := config.GetStore(c.context, c.Namespace, c.ownerInfo).CreateOrUpdate(c.ClusterInfo, c.spec.Mon.Msgr2Port); err != nil {
 		return errors.Wrap(err, "failed to update the global config")
 	}
 

--- a/pkg/operator/ceph/cluster/mon/mon.go
+++ b/pkg/operator/ceph/cluster/mon/mon.go
@@ -472,7 +472,7 @@ func (c *Cluster) initClusterInfo(cephVersion cephver.CephVersion) error {
 	var err error
 
 	// get the cluster info from secret
-	c.ClusterInfo, c.maxMonID, c.mapping, err = CreateOrLoadClusterInfo(c.context, c.Namespace, c.ownerInfo)
+	c.ClusterInfo, c.maxMonID, c.mapping, err = CreateOrLoadClusterInfo(c.context, c.Namespace, &c.spec.Mon, c.ownerInfo)
 	if err != nil {
 		return errors.Wrap(err, "failed to get cluster info")
 	}
@@ -1012,7 +1012,7 @@ func (c *Cluster) saveMonConfig() error {
 
 	// Every time the mon config is updated, must also update the global config so that all daemons
 	// have the most updated version if they restart.
-	if err := config.GetStore(c.context, c.Namespace, c.ownerInfo).CreateOrUpdate(c.ClusterInfo, c.spec.Mon.Msgr2Port); err != nil {
+	if err := config.GetStore(c.context, c.Namespace, c.ownerInfo).CreateOrUpdate(c.ClusterInfo); err != nil {
 		return errors.Wrap(err, "failed to update the global config")
 	}
 

--- a/pkg/operator/ceph/cluster/mon/mon.go
+++ b/pkg/operator/ceph/cluster/mon/mon.go
@@ -544,10 +544,15 @@ func (c *Cluster) clusterInfoToMonConfig(excludedMon string) []*monConfig {
 func (c *Cluster) newMonConfig(monID int, zone string) *monConfig {
 	daemonName := k8sutil.IndexToName(monID)
 
+	msgr1Port := DefaultMsgr1Port
+	if c.spec.Mon.Msgr1Port != 0 {
+		msgr1Port = c.spec.Mon.Msgr1Port
+	}
+
 	return &monConfig{
 		ResourceName: resourceName(daemonName),
 		DaemonName:   daemonName,
-		Port:         DefaultMsgr1Port,
+		Port:         msgr1Port,
 		Zone:         zone,
 		DataPathMap: config.NewStatefulDaemonDataPathMap(
 			c.spec.DataDirHostPath, dataDirRelativeHostPath(daemonName), config.MonType, daemonName, c.Namespace),
@@ -1010,9 +1015,14 @@ func (c *Cluster) saveMonConfig() error {
 		return errors.Wrap(err, "failed to persist expected mons")
 	}
 
+	msgr2Port := DefaultMsgr2Port
+	if c.spec.Mon.Msgr2Port != 0 {
+		msgr2Port = c.spec.Mon.Msgr2Port
+	}
+
 	// Every time the mon config is updated, must also update the global config so that all daemons
 	// have the most updated version if they restart.
-	if err := config.GetStore(c.context, c.Namespace, c.ownerInfo).CreateOrUpdate(c.ClusterInfo); err != nil {
+	if err := config.GetStore(c.context, c.Namespace, c.ownerInfo).CreateOrUpdate(c.ClusterInfo, msgr2Port); err != nil {
 		return errors.Wrap(err, "failed to update the global config")
 	}
 

--- a/pkg/operator/ceph/cluster/mon/node_test.go
+++ b/pkg/operator/ceph/cluster/mon/node_test.go
@@ -179,8 +179,8 @@ func TestHostNetwork(t *testing.T) {
 	assert.NotNil(t, pod)
 	assert.Equal(t, true, pod.Spec.HostNetwork)
 	assert.Equal(t, v1.DNSClusterFirstWithHostNet, pod.Spec.DNSPolicy)
-	val, message := extractArgValue(pod.Spec.Containers[0].Args, "--public-addr")
-	assert.Equal(t, "2.4.6.3", val, message)
+	val, message := extractArgValue(pod.Spec.Containers[0].Args, "--public-addrv")
+	assert.Equal(t, "[v1:2.4.6.3:6789]", val, message)
 	val, message = extractArgValue(pod.Spec.Containers[0].Args, "--public-bind-addr")
 	assert.Equal(t, "", val)
 	assert.Equal(t, "arg not found: --public-bind-addr", message)
@@ -188,8 +188,8 @@ func TestHostNetwork(t *testing.T) {
 	monConfig.Port = 6790
 	pod, err = c.makeMonPod(monConfig, false)
 	assert.NoError(t, err)
-	val, message = extractArgValue(pod.Spec.Containers[0].Args, "--public-addr")
-	assert.Equal(t, "2.4.6.3:6790", val, message)
+	val, message = extractArgValue(pod.Spec.Containers[0].Args, "--public-addrv")
+	assert.Equal(t, "[v1:2.4.6.3:6790]", val, message)
 	assert.NotNil(t, pod)
 }
 

--- a/pkg/operator/ceph/cluster/mon/service.go
+++ b/pkg/operator/ceph/cluster/mon/service.go
@@ -43,7 +43,7 @@ func (c *Cluster) createService(mon *monConfig) (string, error) {
 					Port: mon.Port,
 					// --public-bind-addr=IP with no IP:port has the mon listen on port 6789
 					// regardless of what port the mon advertises (--public-addr) to the outside.
-					TargetPort: intstr.FromInt(int(DefaultMsgr1Port)),
+					TargetPort: intstr.FromInt(int(c.spec.Mon.Msgr1Port)),
 					Protocol:   v1.ProtocolTCP,
 				},
 			},
@@ -56,7 +56,7 @@ func (c *Cluster) createService(mon *monConfig) (string, error) {
 	}
 
 	// If deploying Nautilus or newer we need a new port for the monitor service
-	addServicePort(svcDef, "tcp-msgr2", DefaultMsgr2Port)
+	addServicePort(svcDef, "tcp-msgr2", c.spec.Mon.Msgr2Port)
 
 	// Set the ClusterIP if the service does not exist and we expect a certain cluster IP
 	// For example, in disaster recovery the service might have been deleted accidentally, but we have the
@@ -82,7 +82,7 @@ func (c *Cluster) createService(mon *monConfig) (string, error) {
 	// mon endpoint are not actually like, they remain with the mgrs1 format
 	// however it's interesting to show that monitors can be addressed via 2 different ports
 	// in the end the service has msgr1 and msgr2 ports configured so it's not entirely wrong
-	logger.Infof("mon %q endpoint is [v2:%s:%s,v1:%s:%d]", mon.DaemonName, s.Spec.ClusterIP, strconv.Itoa(int(DefaultMsgr2Port)), s.Spec.ClusterIP, mon.Port)
+	logger.Infof("mon %q endpoint is [v2:%s:%s,v1:%s:%d]", mon.DaemonName, s.Spec.ClusterIP, strconv.Itoa(int(c.spec.Mon.Msgr2Port)), s.Spec.ClusterIP, mon.Port)
 
 	return s.Spec.ClusterIP, nil
 }

--- a/pkg/operator/ceph/cluster/mon/spec.go
+++ b/pkg/operator/ceph/cluster/mon/spec.go
@@ -338,7 +338,7 @@ func (c *Cluster) makeMonDaemonContainer(monConfig *monConfig) corev1.Container 
 	}
 
 	// Add messenger 2 port
-	addContainerPort(container, "tcp-msgr2", 3300)
+	addContainerPort(container, "tcp-msgr2", c.spec.Mon.Msgr2Port)
 
 	return container
 }

--- a/pkg/operator/ceph/cluster/rbd/controller.go
+++ b/pkg/operator/ceph/cluster/rbd/controller.go
@@ -200,7 +200,7 @@ func (r *ReconcileCephRBDMirror) reconcile(request reconcile.Request) (reconcile
 
 	// Populate clusterInfo
 	// Always populate it during each reconcile
-	r.clusterInfo, _, _, err = mon.LoadClusterInfo(r.context, request.NamespacedName.Namespace)
+	r.clusterInfo, _, _, err = mon.LoadClusterInfo(r.context, request.NamespacedName.Namespace, &cephCluster.Spec.Mon)
 	if err != nil {
 		return opcontroller.ImmediateRetryResult, errors.Wrap(err, "failed to populate cluster info")
 	}

--- a/pkg/operator/ceph/cluster/version.go
+++ b/pkg/operator/ceph/cluster/version.go
@@ -175,7 +175,7 @@ func (c *cluster) validateCephVersion(version *cephver.CephVersion) error {
 	// state we are in and if we should upgrade or not
 
 	// Try to load clusterInfo so we can compare the running version with the one from the spec image
-	clusterInfo, _, _, err := mon.LoadClusterInfo(c.context, c.Namespace)
+	clusterInfo, _, _, err := mon.LoadClusterInfo(c.context, c.Namespace, &c.Spec.Mon)
 	if err == nil {
 		// Write connection info (ceph config file and keyring) for ceph commands
 		err = mon.WriteConnectionConfig(c.context, clusterInfo)

--- a/pkg/operator/ceph/config/store.go
+++ b/pkg/operator/ceph/config/store.go
@@ -61,10 +61,10 @@ func GetStore(context *clusterd.Context, namespace string, ownerInfo *k8sutil.Ow
 }
 
 // CreateOrUpdate creates or updates the stored Ceph config based on the cluster info.
-func (s *Store) CreateOrUpdate(clusterInfo *cephclient.ClusterInfo, msgr2Port int32) error {
+func (s *Store) CreateOrUpdate(clusterInfo *cephclient.ClusterInfo) error {
 	ctx := context.TODO()
 	// these are used for all ceph daemons on the commandline and must *always* be stored
-	if err := s.createOrUpdateMonHostSecrets(ctx, clusterInfo, msgr2Port); err != nil {
+	if err := s.createOrUpdateMonHostSecrets(ctx, clusterInfo); err != nil {
 		return errors.Wrap(err, "failed to store mon host configs")
 	}
 
@@ -72,11 +72,11 @@ func (s *Store) CreateOrUpdate(clusterInfo *cephclient.ClusterInfo, msgr2Port in
 }
 
 // update "mon_host" and "mon_initial_members" in the stored config
-func (s *Store) createOrUpdateMonHostSecrets(ctx context.Context, clusterInfo *cephclient.ClusterInfo, msgr2Port int32) error {
+func (s *Store) createOrUpdateMonHostSecrets(ctx context.Context, clusterInfo *cephclient.ClusterInfo) error {
 
 	// extract a list of just the monitor names, which will populate the "mon initial members"
 	// and "mon hosts" global config field
-	members, hosts := cephclient.PopulateMonHostMembers(clusterInfo.Monitors, msgr2Port)
+	members, hosts := cephclient.PopulateMonHostMembers(clusterInfo)
 
 	// store these in a secret instead of the configmap; secrets are required by CSI drivers
 	secret := &v1.Secret{

--- a/pkg/operator/ceph/config/store.go
+++ b/pkg/operator/ceph/config/store.go
@@ -61,10 +61,10 @@ func GetStore(context *clusterd.Context, namespace string, ownerInfo *k8sutil.Ow
 }
 
 // CreateOrUpdate creates or updates the stored Ceph config based on the cluster info.
-func (s *Store) CreateOrUpdate(clusterInfo *cephclient.ClusterInfo) error {
+func (s *Store) CreateOrUpdate(clusterInfo *cephclient.ClusterInfo, msgr2Port int32) error {
 	ctx := context.TODO()
 	// these are used for all ceph daemons on the commandline and must *always* be stored
-	if err := s.createOrUpdateMonHostSecrets(ctx, clusterInfo); err != nil {
+	if err := s.createOrUpdateMonHostSecrets(ctx, clusterInfo, msgr2Port); err != nil {
 		return errors.Wrap(err, "failed to store mon host configs")
 	}
 
@@ -72,11 +72,11 @@ func (s *Store) CreateOrUpdate(clusterInfo *cephclient.ClusterInfo) error {
 }
 
 // update "mon_host" and "mon_initial_members" in the stored config
-func (s *Store) createOrUpdateMonHostSecrets(ctx context.Context, clusterInfo *cephclient.ClusterInfo) error {
+func (s *Store) createOrUpdateMonHostSecrets(ctx context.Context, clusterInfo *cephclient.ClusterInfo, msgr2Port int32) error {
 
 	// extract a list of just the monitor names, which will populate the "mon initial members"
 	// and "mon hosts" global config field
-	members, hosts := cephclient.PopulateMonHostMembers(clusterInfo.Monitors)
+	members, hosts := cephclient.PopulateMonHostMembers(clusterInfo.Monitors, msgr2Port)
 
 	// store these in a secret instead of the configmap; secrets are required by CSI drivers
 	secret := &v1.Secret{

--- a/pkg/operator/ceph/config/store_test.go
+++ b/pkg/operator/ceph/config/store_test.go
@@ -66,11 +66,11 @@ func TestStore(t *testing.T) {
 	i1 := clienttest.CreateTestClusterInfo(1) // cluster w/ one mon
 	i3 := clienttest.CreateTestClusterInfo(3) // same cluster w/ 3 mons
 
-	err := s.CreateOrUpdate(i1, 3300)
+	err := s.CreateOrUpdate(i1)
 	assert.NoError(t, err)
 	assertConfigStore(i1)
 
-	err = s.CreateOrUpdate(i3, 3300)
+	err = s.CreateOrUpdate(i3)
 	assert.NoError(t, err)
 	assertConfigStore(i3)
 }
@@ -84,7 +84,7 @@ func TestEnvVarsAndFlags(t *testing.T) {
 	ownerInfo := cephclient.NewMinimumOwnerInfoWithOwnerRef()
 
 	s := GetStore(ctx, ns, ownerInfo)
-	err := s.CreateOrUpdate(clienttest.CreateTestClusterInfo(3), 3300)
+	err := s.CreateOrUpdate(clienttest.CreateTestClusterInfo(3))
 	assert.NoError(t, err)
 
 	v := StoredMonHostEnvVars()

--- a/pkg/operator/ceph/config/store_test.go
+++ b/pkg/operator/ceph/config/store_test.go
@@ -66,11 +66,11 @@ func TestStore(t *testing.T) {
 	i1 := clienttest.CreateTestClusterInfo(1) // cluster w/ one mon
 	i3 := clienttest.CreateTestClusterInfo(3) // same cluster w/ 3 mons
 
-	err := s.CreateOrUpdate(i1)
+	err := s.CreateOrUpdate(i1, 3300)
 	assert.NoError(t, err)
 	assertConfigStore(i1)
 
-	err = s.CreateOrUpdate(i3)
+	err = s.CreateOrUpdate(i3, 3300)
 	assert.NoError(t, err)
 	assertConfigStore(i3)
 }
@@ -84,7 +84,7 @@ func TestEnvVarsAndFlags(t *testing.T) {
 	ownerInfo := cephclient.NewMinimumOwnerInfoWithOwnerRef()
 
 	s := GetStore(ctx, ns, ownerInfo)
-	err := s.CreateOrUpdate(clienttest.CreateTestClusterInfo(3))
+	err := s.CreateOrUpdate(clienttest.CreateTestClusterInfo(3), 3300)
 	assert.NoError(t, err)
 
 	v := StoredMonHostEnvVars()

--- a/pkg/operator/ceph/disruption/clusterdisruption/reconcile.go
+++ b/pkg/operator/ceph/disruption/clusterdisruption/reconcile.go
@@ -219,6 +219,7 @@ func (c *ClusterMap) GetClusterInfo(namespace string) *cephClient.ClusterInfo {
 
 	clusterInfo := cephClient.NewClusterInfo(namespace, cluster.ObjectMeta.GetName())
 	clusterInfo.CephCred.Username = cephClient.AdminUsername
+	clusterInfo.MonSpec = cluster.Spec.Mon
 	return clusterInfo
 }
 

--- a/pkg/operator/ceph/file/controller.go
+++ b/pkg/operator/ceph/file/controller.go
@@ -228,7 +228,7 @@ func (r *ReconcileCephFilesystem) reconcile(request reconcile.Request) (reconcil
 
 	// Populate clusterInfo
 	// Always populate it during each reconcile
-	clusterInfo, _, _, err := mon.LoadClusterInfo(r.context, request.NamespacedName.Namespace)
+	clusterInfo, _, _, err := mon.LoadClusterInfo(r.context, request.NamespacedName.Namespace, &cephCluster.Spec.Mon)
 	if err != nil {
 		return reconcile.Result{}, errors.Wrap(err, "failed to populate cluster info")
 	}

--- a/pkg/operator/ceph/file/mirror/controller.go
+++ b/pkg/operator/ceph/file/mirror/controller.go
@@ -187,7 +187,7 @@ func (r *ReconcileFilesystemMirror) reconcile(request reconcile.Request) (reconc
 	r.cephClusterSpec = &cephCluster.Spec
 
 	// Populate clusterInfo
-	r.clusterInfo, _, _, err = mon.LoadClusterInfo(r.context, request.NamespacedName.Namespace)
+	r.clusterInfo, _, _, err = mon.LoadClusterInfo(r.context, request.NamespacedName.Namespace, &cephCluster.Spec.Mon)
 	if err != nil {
 		return opcontroller.ImmediateRetryResult, errors.Wrap(err, "failed to populate cluster info")
 	}

--- a/pkg/operator/ceph/nfs/controller.go
+++ b/pkg/operator/ceph/nfs/controller.go
@@ -188,7 +188,7 @@ func (r *ReconcileCephNFS) reconcile(request reconcile.Request) (reconcile.Resul
 
 	// Populate clusterInfo
 	// Always populate it during each reconcile
-	r.clusterInfo, _, _, err = mon.LoadClusterInfo(r.context, request.NamespacedName.Namespace)
+	r.clusterInfo, _, _, err = mon.LoadClusterInfo(r.context, request.NamespacedName.Namespace, &cephCluster.Spec.Mon)
 	if err != nil {
 		return reconcile.Result{}, errors.Wrap(err, "failed to populate cluster info")
 	}

--- a/pkg/operator/ceph/object/controller.go
+++ b/pkg/operator/ceph/object/controller.go
@@ -234,7 +234,7 @@ func (r *ReconcileCephObjectStore) reconcile(request reconcile.Request) (reconci
 	}
 
 	// Populate clusterInfo during each reconcile
-	r.clusterInfo, _, _, err = mon.LoadClusterInfo(r.context, request.NamespacedName.Namespace)
+	r.clusterInfo, _, _, err = mon.LoadClusterInfo(r.context, request.NamespacedName.Namespace, &cephCluster.Spec.Mon)
 	if err != nil {
 		return reconcile.Result{}, cephObjectStore, errors.Wrap(err, "failed to populate cluster info")
 	}

--- a/pkg/operator/ceph/object/realm/controller.go
+++ b/pkg/operator/ceph/object/realm/controller.go
@@ -149,7 +149,7 @@ func (r *ReconcileObjectRealm) reconcile(request reconcile.Request) (reconcile.R
 	}
 
 	// Make sure a CephCluster is present otherwise do nothing
-	_, isReadyToReconcile, cephClusterExists, reconcileResponse := opcontroller.IsReadyToReconcile(r.client, r.context, request.NamespacedName, controllerName)
+	cephCluster, isReadyToReconcile, cephClusterExists, reconcileResponse := opcontroller.IsReadyToReconcile(r.client, r.context, request.NamespacedName, controllerName)
 	if !isReadyToReconcile {
 		// This handles the case where the Ceph Cluster is gone and we want to delete that CR
 		if !cephObjectRealm.GetDeletionTimestamp().IsZero() && !cephClusterExists {
@@ -168,7 +168,7 @@ func (r *ReconcileObjectRealm) reconcile(request reconcile.Request) (reconcile.R
 	}
 
 	// Populate clusterInfo during each reconcile
-	r.clusterInfo, _, _, err = mon.LoadClusterInfo(r.context, request.NamespacedName.Namespace)
+	r.clusterInfo, _, _, err = mon.LoadClusterInfo(r.context, request.NamespacedName.Namespace, &cephCluster.Spec.Mon)
 	if err != nil {
 		return reconcile.Result{}, errors.Wrap(err, "failed to populate cluster info")
 	}

--- a/pkg/operator/ceph/object/user/controller.go
+++ b/pkg/operator/ceph/object/user/controller.go
@@ -186,7 +186,7 @@ func (r *ReconcileObjectStoreUser) reconcile(request reconcile.Request) (reconci
 	r.cephClusterSpec = &cephCluster.Spec
 
 	// Populate clusterInfo during each reconcile
-	r.clusterInfo, _, _, err = mon.LoadClusterInfo(r.context, request.NamespacedName.Namespace)
+	r.clusterInfo, _, _, err = mon.LoadClusterInfo(r.context, request.NamespacedName.Namespace, &cephCluster.Spec.Mon)
 	if err != nil {
 		return reconcile.Result{}, errors.Wrap(err, "failed to populate cluster info")
 	}

--- a/pkg/operator/ceph/object/zone/controller.go
+++ b/pkg/operator/ceph/object/zone/controller.go
@@ -165,7 +165,7 @@ func (r *ReconcileObjectZone) reconcile(request reconcile.Request) (reconcile.Re
 	}
 
 	// Populate clusterInfo during each reconcile
-	r.clusterInfo, _, _, err = mon.LoadClusterInfo(r.context, request.NamespacedName.Namespace)
+	r.clusterInfo, _, _, err = mon.LoadClusterInfo(r.context, request.NamespacedName.Namespace, &cephCluster.Spec.Mon)
 	if err != nil {
 		return reconcile.Result{}, errors.Wrap(err, "failed to populate cluster info")
 	}

--- a/pkg/operator/ceph/object/zonegroup/controller.go
+++ b/pkg/operator/ceph/object/zonegroup/controller.go
@@ -142,7 +142,7 @@ func (r *ReconcileObjectZoneGroup) reconcile(request reconcile.Request) (reconci
 	}
 
 	// Make sure a CephCluster is present otherwise do nothing
-	_, isReadyToReconcile, cephClusterExists, reconcileResponse := opcontroller.IsReadyToReconcile(r.client, r.context, request.NamespacedName, controllerName)
+	cephCluster, isReadyToReconcile, cephClusterExists, reconcileResponse := opcontroller.IsReadyToReconcile(r.client, r.context, request.NamespacedName, controllerName)
 	if !isReadyToReconcile {
 		// This handles the case where the Ceph Cluster is gone and we want to delete that CR
 		if !cephObjectZoneGroup.GetDeletionTimestamp().IsZero() && !cephClusterExists {
@@ -161,7 +161,7 @@ func (r *ReconcileObjectZoneGroup) reconcile(request reconcile.Request) (reconci
 	}
 
 	// Populate clusterInfo during each reconcile
-	r.clusterInfo, _, _, err = mon.LoadClusterInfo(r.context, request.NamespacedName.Namespace)
+	r.clusterInfo, _, _, err = mon.LoadClusterInfo(r.context, request.NamespacedName.Namespace, &cephCluster.Spec.Mon)
 	if err != nil {
 		return reconcile.Result{}, errors.Wrap(err, "failed to populate cluster info")
 	}

--- a/pkg/operator/ceph/pool/controller.go
+++ b/pkg/operator/ceph/pool/controller.go
@@ -190,12 +190,13 @@ func (r *ReconcileCephBlockPool) reconcile(request reconcile.Request) (reconcile
 	}
 
 	// Populate clusterInfo during each reconcile
-	clusterInfo, _, _, err := mon.LoadClusterInfo(r.context, request.NamespacedName.Namespace)
+	clusterInfo, _, _, err := mon.LoadClusterInfo(r.context, request.NamespacedName.Namespace, &cephCluster.Spec.Mon)
 	if err != nil {
 		return opcontroller.ImmediateRetryResult, errors.Wrap(err, "failed to populate cluster info")
 	}
 	r.clusterInfo = clusterInfo
 	r.clusterInfo.NetworkSpec = cephCluster.Spec.Network
+	r.clusterInfo.MonSpec = cephCluster.Spec.Mon
 
 	// Initialize the channel for this pool
 	// This allows us to track multiple CephBlockPool in the same namespace


### PR DESCRIPTION
Required when you want to host MONs from different ceph clusters
on same nodes.
