### PR TITLE
user: fix typo preventing creation of users caps

### DIFF
--- a/pkg/operator/ceph/object/user/controller.go
+++ b/pkg/operator/ceph/object/user/controller.go
@@ -423,7 +423,7 @@ func generateUserConfig(user *cephv1.CephObjectStoreUser) admin.User {
 			userConfig.UserCaps += fmt.Sprintf("users=%s;", user.Spec.Capabilities.User)
 		}
 		if user.Spec.Capabilities.Users != "" {
-			userConfig.UserCaps += fmt.Sprintf("users=%s;", user.Spec.Capabilities.User)
+			userConfig.UserCaps += fmt.Sprintf("users=%s;", user.Spec.Capabilities.Users)
 		}
 		if user.Spec.Capabilities.Buckets != "" {
 			userConfig.UserCaps += fmt.Sprintf("buckets=%s;", user.Spec.Capabilities.Buckets)

--- a/pkg/operator/ceph/object/user/controller_test.go
+++ b/pkg/operator/ceph/object/user/controller_test.go
@@ -461,7 +461,7 @@ func TestCreateOrUpdateCephUser(t *testing.T) {
 	t.Run("setting Capabilities for the user", func(t *testing.T) {
 		objectUser.Spec.Quotas = nil
 		objectUser.Spec.Capabilities = &cephv1.ObjectUserCapSpec{
-			User:    "read",
+			Users:   "read",
 			Buckets: "read",
 		}
 		userConfig = generateUserConfig(objectUser)
@@ -510,7 +510,7 @@ func TestCreateOrUpdateCephUser(t *testing.T) {
 
 	t.Run("setting both Quotas and Capabilities for the user", func(t *testing.T) {
 		objectUser.Spec.Capabilities = &cephv1.ObjectUserCapSpec{
-			User:    "read",
+			Users:   "read",
 			Buckets: "read",
 		}
 		objectUser.Spec.Quotas = &cephv1.ObjectUserQuotaSpec{MaxBuckets: &maxbucket, MaxObjects: &maxobject, MaxSize: &maxsize}


### PR DESCRIPTION
Issue introduced by https://github.com/criteo-forks/rook/commit/f91e794c4dc3f6ecbd2a0ebb2dc5f5c045fc8179

But fixed before submission to upstream
https://github.com/rook/rook/pull/12460/files
