### PR TITLE
[BACKPORT] add resource requirement for cmd reporter job

### DIFF
--- a/Documentation/CRDs/Cluster/ceph-cluster-crd.md
+++ b/Documentation/CRDs/Cluster/ceph-cluster-crd.md
@@ -511,6 +511,7 @@ You can set resource requests/limits for Rook components through the [Resource R
 It scrapes for Ceph daemon core dumps and sends them to the Ceph manager crash module so that core dumps are centralized and can be easily listed/accessed.
 You can read more about the [Ceph Crash module](https://docs.ceph.com/docs/master/mgr/crash/).
 * `logcollector`: Set resource requests/limits for the log collector. When enabled, this container runs as side-car to each Ceph daemons.
+* `cmd-reporter`: Set resource requests/limits for the jobs that detect the ceph version and collect network info.
 * `cleanup`: Set resource requests/limits for cleanup job, responsible for wiping cluster's data after uninstall
 
 In order to provide the best possible experience running Ceph in containers, Rook internally recommends minimum memory limits if resource limits are passed.

--- a/deploy/examples/cluster.yaml
+++ b/deploy/examples/cluster.yaml
@@ -93,15 +93,15 @@ spec:
     # enable the Multus network provider
     #provider: multus
     #selectors:
-      # The selector keys are required to be `public` and `cluster`.
-      # Based on the configuration, the operator will do the following:
-      #   1. if only the `public` selector key is specified both public_network and cluster_network Ceph settings will listen on that interface
-      #   2. if both `public` and `cluster` selector keys are specified the first one will point to 'public_network' flag and the second one to 'cluster_network'
-      #
-      # In order to work, each selector value must match a NetworkAttachmentDefinition object in Multus
-      #
-      #public: public-conf --> NetworkAttachmentDefinition object name in Multus
-      #cluster: cluster-conf --> NetworkAttachmentDefinition object name in Multus
+    # The selector keys are required to be `public` and `cluster`.
+    # Based on the configuration, the operator will do the following:
+    #   1. if only the `public` selector key is specified both public_network and cluster_network Ceph settings will listen on that interface
+    #   2. if both `public` and `cluster` selector keys are specified the first one will point to 'public_network' flag and the second one to 'cluster_network'
+    #
+    # In order to work, each selector value must match a NetworkAttachmentDefinition object in Multus
+    #
+    #public: public-conf --> NetworkAttachmentDefinition object name in Multus
+    #cluster: cluster-conf --> NetworkAttachmentDefinition object name in Multus
     # Provide internet protocol version. IPv6, IPv4 or empty string are valid options. Empty string would mean IPv4
     #ipFamily: "IPv6"
     # Ceph daemons to listen on both IPv4 and Ipv6 networks
@@ -144,76 +144,77 @@ spec:
   # To control where various services will be scheduled by kubernetes, use the placement configuration sections below.
   # The example under 'all' would have all services scheduled on kubernetes nodes labeled with 'role=storage-node' and
   # tolerate taints with a key of 'storage-node'.
-#  placement:
-#    all:
-#      nodeAffinity:
-#        requiredDuringSchedulingIgnoredDuringExecution:
-#          nodeSelectorTerms:
-#          - matchExpressions:
-#            - key: role
-#              operator: In
-#              values:
-#              - storage-node
-#      podAffinity:
-#      podAntiAffinity:
-#      topologySpreadConstraints:
-#      tolerations:
-#      - key: storage-node
-#        operator: Exists
-# The above placement information can also be specified for mon, osd, and mgr components
-#    mon:
-# Monitor deployments may contain an anti-affinity rule for avoiding monitor
-# collocation on the same node. This is a required rule when host network is used
-# or when AllowMultiplePerNode is false. Otherwise this anti-affinity rule is a
-# preferred rule with weight: 50.
-#    osd:
-#    prepareosd:
-#    mgr:
-#    cleanup:
+  #  placement:
+  #    all:
+  #      nodeAffinity:
+  #        requiredDuringSchedulingIgnoredDuringExecution:
+  #          nodeSelectorTerms:
+  #          - matchExpressions:
+  #            - key: role
+  #              operator: In
+  #              values:
+  #              - storage-node
+  #      podAffinity:
+  #      podAntiAffinity:
+  #      topologySpreadConstraints:
+  #      tolerations:
+  #      - key: storage-node
+  #        operator: Exists
+  # The above placement information can also be specified for mon, osd, and mgr components
+  #    mon:
+  # Monitor deployments may contain an anti-affinity rule for avoiding monitor
+  # collocation on the same node. This is a required rule when host network is used
+  # or when AllowMultiplePerNode is false. Otherwise this anti-affinity rule is a
+  # preferred rule with weight: 50.
+  #    osd:
+  #    prepareosd:
+  #    mgr:
+  #    cleanup:
   annotations:
-#    all:
-#    mon:
-#    osd:
-#    cleanup:
-#    prepareosd:
-# clusterMetadata annotations will be applied to only `rook-ceph-mon-endpoints` configmap and the `rook-ceph-mon` and `rook-ceph-admin-keyring` secrets.
-# And clusterMetadata annotations will not be merged with `all` annotations.
-#    clusterMetadata:
-#       kubed.appscode.com/sync: "true"
-# If no mgr annotations are set, prometheus scrape annotations will be set by default.
-#    mgr:
+  #    all:
+  #    mon:
+  #    osd:
+  #    cleanup:
+  #    prepareosd:
+  # clusterMetadata annotations will be applied to only `rook-ceph-mon-endpoints` configmap and the `rook-ceph-mon` and `rook-ceph-admin-keyring` secrets.
+  # And clusterMetadata annotations will not be merged with `all` annotations.
+  #    clusterMetadata:
+  #       kubed.appscode.com/sync: "true"
+  # If no mgr annotations are set, prometheus scrape annotations will be set by default.
+  #    mgr:
   labels:
-#    all:
-#    mon:
-#    osd:
-#    cleanup:
-#    mgr:
-#    prepareosd:
-# monitoring is a list of key-value pairs. It is injected into all the monitoring resources created by operator.
-# These labels can be passed as LabelSelector to Prometheus
-#    monitoring:
-#    crashcollector:
+  #    all:
+  #    mon:
+  #    osd:
+  #    cleanup:
+  #    mgr:
+  #    prepareosd:
+  # monitoring is a list of key-value pairs. It is injected into all the monitoring resources created by operator.
+  # These labels can be passed as LabelSelector to Prometheus
+  #    monitoring:
+  #    crashcollector:
   resources:
-# The requests and limits set here, allow the mgr pod to use half of one CPU core and 1 gigabyte of memory
-#    mgr:
-#      limits:
-#        cpu: "500m"
-#        memory: "1024Mi"
-#      requests:
-#        cpu: "500m"
-#        memory: "1024Mi"
-# The above example requests/limits can also be added to the other components
-#    mon:
-#    osd:
-# For OSD it also is a possible to specify requests/limits based on device class
-#    osd-hdd:
-#    osd-ssd:
-#    osd-nvme:
-#    prepareosd:
-#    mgr-sidecar:
-#    crashcollector:
-#    logcollector:
-#    cleanup:
+  # The requests and limits set here, allow the mgr pod to use half of one CPU core and 1 gigabyte of memory
+  #    mgr:
+  #      limits:
+  #        cpu: "500m"
+  #        memory: "1024Mi"
+  #      requests:
+  #        cpu: "500m"
+  #        memory: "1024Mi"
+  # The above example requests/limits can also be added to the other components
+  #    mon:
+  #    osd:
+  # For OSD it also is a possible to specify requests/limits based on device class
+  #    osd-hdd:
+  #    osd-ssd:
+  #    osd-nvme:
+  #    prepareosd:
+  #    mgr-sidecar:
+  #    crashcollector:
+  #    logcollector:
+  #    cleanup:
+  #    cmd-reporter:
   # The option to automatically remove OSDs that are out and are safe to destroy.
   removeOSDsIfOutAndSafeToRemove: false
   priorityClassNames:
@@ -233,8 +234,8 @@ spec:
       # journalSizeMB: "1024"  # uncomment if the disks are 20 GB or smaller
       # osdsPerDevice: "1" # this value can be overridden at the node or device level
       # encryptedDevice: "true" # the default value for this option is "false"
-# Individual nodes and their config can be specified as well, but 'useAllNodes' above must be set to false. Then, only the named
-# nodes below will be used as storage resources.  Each node's 'name' field should match their 'kubernetes.io/hostname' label.
+    # Individual nodes and their config can be specified as well, but 'useAllNodes' above must be set to false. Then, only the named
+    # nodes below will be used as storage resources.  Each node's 'name' field should match their 'kubernetes.io/hostname' label.
     # nodes:
     #   - name: "172.17.4.201"
     #     devices: # specific devices to use for storage can be specified for each node

--- a/pkg/apis/ceph.rook.io/v1/resources.go
+++ b/pkg/apis/ceph.rook.io/v1/resources.go
@@ -31,6 +31,8 @@ const (
 	ResourcesKeyOSD = "osd"
 	// ResourcesKeyPrepareOSD represents the name of resource in the CR for the osd prepare job
 	ResourcesKeyPrepareOSD = "prepareosd"
+	// ResourcesKeyCmdReporter represents the name of resource in the CR for the detect version and network jobs
+	ResourcesKeyCmdReporter = "cmd-reporter"
 	// ResourcesKeyMDS represents the name of resource in the CR for the mds
 	ResourcesKeyMDS = "mds"
 	// ResourcesKeyCrashCollector represents the name of resource in the CR for the crash
@@ -45,22 +47,22 @@ const (
 	ResourcesKeyCleanup = "cleanup"
 )
 
-// GetMgrResources returns the placement for the MGR service
+// GetMgrResources returns the resources for the MGR service
 func GetMgrResources(p ResourceSpec) v1.ResourceRequirements {
 	return p[ResourcesKeyMgr]
 }
 
-// GetMgrSidecarResources returns the placement for the MGR sidecar container
+// GetMgrSidecarResources returns the resources for the MGR sidecar container
 func GetMgrSidecarResources(p ResourceSpec) v1.ResourceRequirements {
 	return p[ResourcesKeyMgrSidecar]
 }
 
-// GetMonResources returns the placement for the monitors
+// GetMonResources returns the resources for the monitors
 func GetMonResources(p ResourceSpec) v1.ResourceRequirements {
 	return p[ResourcesKeyMon]
 }
 
-// GetOSDResources returns the placement for all OSDs or for OSDs of specified device class (hdd, nvme, ssd)
+// GetOSDResources returns the resources for all OSDs or for OSDs of specified device class (hdd, nvme, ssd)
 func GetOSDResources(p ResourceSpec, deviceClass string) v1.ResourceRequirements {
 	if deviceClass == "" {
 		return p[ResourcesKeyOSD]
@@ -78,22 +80,27 @@ func getOSDResourceKeyForDeviceClass(deviceClass string) string {
 	return ResourcesKeyOSD + "-" + deviceClass
 }
 
-// GetPrepareOSDResources returns the placement for the OSDs prepare job
+// GetPrepareOSDResources returns the resources for the OSDs prepare job
 func GetPrepareOSDResources(p ResourceSpec) v1.ResourceRequirements {
 	return p[ResourcesKeyPrepareOSD]
 }
 
-// GetCrashCollectorResources returns the placement for the crash daemon
+// GetCrashCollectorResources returns the resources for the crash daemon
 func GetCrashCollectorResources(p ResourceSpec) v1.ResourceRequirements {
 	return p[ResourcesKeyCrashCollector]
 }
 
-// GetLogCollectorResources returns the placement for the crash daemon
+// GetCmdReporterResources returns the resources for the detect version job
+func GetCmdReporterResources(p ResourceSpec) v1.ResourceRequirements {
+	return p[ResourcesKeyCmdReporter]
+}
+
+// GetLogCollectorResources returns the resources for the crash daemon
 func GetLogCollectorResources(p ResourceSpec) v1.ResourceRequirements {
 	return p[ResourcesKeyLogCollector]
 }
 
-// GetCleanupResources returns the placement for the cleanup job
+// GetCleanupResources returns the resources for the cleanup job
 func GetCleanupResources(p ResourceSpec) v1.ResourceRequirements {
 	return p[ResourcesKeyCleanup]
 }

--- a/pkg/operator/ceph/controller/version.go
+++ b/pkg/operator/ceph/controller/version.go
@@ -74,6 +74,7 @@ func DetectCephVersion(ctx context.Context, rookImage, namespace, jobName string
 		rookImage,
 		cephImage,
 		cephClusterSpec.CephVersion.ImagePullPolicy,
+		cephClusterSpec.Resources,
 	)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to set up ceph version job")

--- a/pkg/operator/ceph/csi/controller.go
+++ b/pkg/operator/ceph/csi/controller.go
@@ -188,6 +188,7 @@ func (r *ReconcileCSI) reconcile(request reconcile.Request) (reconcile.Result, e
 			logger.Debugf("ceph cluster %q has cleanup policy, the cluster will soon go away, no need to reconcile the csi driver", cluster.Name)
 			return reconcile.Result{}, nil
 		}
+
 		holderEnabled := !csiHostNetworkEnabled || cluster.Spec.Network.IsMultus()
 		// Do we have a multus cluster or csi host network disabled?
 		// If so deploy the plugin holder with the fsid attached
@@ -242,7 +243,7 @@ func (r *ReconcileCSI) reconcile(request reconcile.Request) (reconcile.Result, e
 	}
 	CustomCSICephConfigExists = exists
 
-	err = r.validateAndConfigureDrivers(serverVersion, ownerInfo)
+	err = r.validateAndConfigureDrivers(serverVersion, ownerInfo, cephClusters.Items[0].Spec.Resources)
 	if err != nil {
 		return opcontroller.ImmediateRetryResult, errors.Wrap(err, "failed to configure ceph csi")
 	}

--- a/pkg/operator/ceph/csi/csi.go
+++ b/pkg/operator/ceph/csi/csi.go
@@ -22,13 +22,15 @@ import (
 	"strings"
 	"time"
 
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+
 	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/version"
 )
 
-func (r *ReconcileCSI) validateAndConfigureDrivers(serverVersion *version.Info, ownerInfo *k8sutil.OwnerInfo) error {
+func (r *ReconcileCSI) validateAndConfigureDrivers(serverVersion *version.Info, ownerInfo *k8sutil.OwnerInfo, resources cephv1.ResourceSpec) error {
 	var (
 		v   *CephCSIVersion
 		err error
@@ -43,7 +45,7 @@ func (r *ReconcileCSI) validateAndConfigureDrivers(serverVersion *version.Info, 
 	}
 
 	if !AllowUnsupported && CSIEnabled() {
-		if v, err = r.validateCSIVersion(ownerInfo); err != nil {
+		if v, err = r.validateCSIVersion(ownerInfo, resources); err != nil {
 			return errors.Wrapf(err, "invalid csi version")
 		}
 	} else {

--- a/pkg/operator/ceph/csi/spec.go
+++ b/pkg/operator/ceph/csi/spec.go
@@ -22,6 +22,8 @@ import (
 	"fmt"
 	"time"
 
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+
 	"github.com/rook/rook/pkg/operator/ceph/cluster/telemetry"
 	opcontroller "github.com/rook/rook/pkg/operator/ceph/controller"
 	"github.com/rook/rook/pkg/operator/k8sutil"
@@ -34,6 +36,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	k8scsi "k8s.io/api/storage/v1beta1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/version"
@@ -739,7 +742,7 @@ func (r *ReconcileCSI) applyCephClusterNetworkConfig(ctx context.Context, object
 }
 
 // ValidateCSIVersion checks if the configured ceph-csi image is supported
-func (r *ReconcileCSI) validateCSIVersion(ownerInfo *k8sutil.OwnerInfo) (*CephCSIVersion, error) {
+func (r *ReconcileCSI) validateCSIVersion(ownerInfo *k8sutil.OwnerInfo, resources cephv1.ResourceSpec) (*CephCSIVersion, error) {
 	timeout := 15 * time.Minute
 
 	logger.Infof("detecting the ceph csi image version for image %q", CSIParam.CSIPluginImage)
@@ -755,6 +758,7 @@ func (r *ReconcileCSI) validateCSIVersion(ownerInfo *k8sutil.OwnerInfo) (*CephCS
 		r.opConfig.Image,
 		CSIParam.CSIPluginImage,
 		v1.PullPolicy(CSIParam.ImagePullPolicy),
+		resources,
 	)
 
 	if err != nil {

--- a/pkg/operator/k8sutil/cmdreporter/cmdreporter.go
+++ b/pkg/operator/k8sutil/cmdreporter/cmdreporter.go
@@ -23,6 +23,8 @@ import (
 	"strconv"
 	"time"
 
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+
 	"github.com/coreos/pkg/capnslog"
 	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/daemon/util"
@@ -75,6 +77,7 @@ type cmdReporterCfg struct {
 	rookImage       string
 	runImage        string
 	imagePullPolicy v1.PullPolicy
+	resources       cephv1.ResourceSpec
 }
 
 // New creates a new CmdReporter.
@@ -96,6 +99,7 @@ func New(
 	cmd, args []string,
 	rookImage, runImage string,
 	imagePullPolicy v1.PullPolicy,
+	resources cephv1.ResourceSpec,
 ) (*CmdReporter, error) {
 	cfg := &cmdReporterCfg{
 		clientset:       clientset,
@@ -108,6 +112,7 @@ func New(
 		rookImage:       rookImage,
 		runImage:        runImage,
 		imagePullPolicy: imagePullPolicy,
+		resources:       resources,
 	}
 
 	// Validate contents of config struct, not inputs to function to catch any developer errors
@@ -341,6 +346,7 @@ func (cr *cmdReporterCfg) initContainers() []v1.Container {
 		},
 		Image:           cr.rookImage,
 		ImagePullPolicy: cr.imagePullPolicy,
+		Resources:       cephv1.GetCmdReporterResources(cr.resources),
 	}
 	_, copyBinsMount := copyBinariesVolAndMount()
 	c.VolumeMounts = []v1.VolumeMount{copyBinsMount}
@@ -371,6 +377,7 @@ func (cr *cmdReporterCfg) container() (*v1.Container, error) {
 		},
 		Image:           cr.runImage,
 		ImagePullPolicy: cr.imagePullPolicy,
+		Resources:       cephv1.GetCmdReporterResources(cr.resources),
 	}
 	if cr.needToCopyBinaries() {
 		_, copyBinsMount := copyBinariesVolAndMount()


### PR DESCRIPTION
If the cmd-reporter key is set under the resources
element in the CephCluster CR, the memory and cpu request
and limits will be set on the ceph detect version job
and network job accordingly.
original commit: f489f99e13de2b335f2ea007738e35fd948cbf60 