### PR TITLE
[CRITEO][BACKPORT] don't delete exporter service on daemon deletion

### DIFF
--- a/Documentation/CRDs/Cluster/ceph-cluster-crd.md
+++ b/Documentation/CRDs/Cluster/ceph-cluster-crd.md
@@ -606,6 +606,7 @@ You can set resource requests/limits for Rook components through the [Resource R
 It scrapes for Ceph daemon core dumps and sends them to the Ceph manager crash module so that core dumps are centralized and can be easily listed/accessed.
 You can read more about the [Ceph Crash module](https://docs.ceph.com/docs/master/mgr/crash/).
 * `logcollector`: Set resource requests/limits for the log collector. When enabled, this container runs as side-car to each Ceph daemons.
+* `cmd-reporter`: Set resource requests/limits for the jobs that detect the ceph version and collect network info.
 * `cleanup`: Set resource requests/limits for cleanup job, responsible for wiping cluster's data after uninstall
 * `exporter`: Set resource requests/limits for Ceph exporter.
 

--- a/pkg/apis/ceph.rook.io/v1/resources.go
+++ b/pkg/apis/ceph.rook.io/v1/resources.go
@@ -31,6 +31,8 @@ const (
 	ResourcesKeyOSD = "osd"
 	// ResourcesKeyPrepareOSD represents the name of resource in the CR for the osd prepare job
 	ResourcesKeyPrepareOSD = "prepareosd"
+	// ResourcesKeyCmdReporter represents the name of resource in the CR for the detect version and network jobs
+	ResourcesKeyCmdReporter = "cmd-reporter"
 	// ResourcesKeyMDS represents the name of resource in the CR for the mds
 	ResourcesKeyMDS = "mds"
 	// ResourcesKeyCrashCollector represents the name of resource in the CR for the crash
@@ -47,22 +49,22 @@ const (
 	ResourcesKeyCephExporter = "exporter"
 )
 
-// GetMgrResources returns the placement for the MGR service
+// GetMgrResources returns the resources for the MGR service
 func GetMgrResources(p ResourceSpec) v1.ResourceRequirements {
 	return p[ResourcesKeyMgr]
 }
 
-// GetMgrSidecarResources returns the placement for the MGR sidecar container
+// GetMgrSidecarResources returns the resources for the MGR sidecar container
 func GetMgrSidecarResources(p ResourceSpec) v1.ResourceRequirements {
 	return p[ResourcesKeyMgrSidecar]
 }
 
-// GetMonResources returns the placement for the monitors
+// GetMonResources returns the resources for the monitors
 func GetMonResources(p ResourceSpec) v1.ResourceRequirements {
 	return p[ResourcesKeyMon]
 }
 
-// GetOSDResources returns the placement for all OSDs or for OSDs of specified device class (hdd, nvme, ssd)
+// GetOSDResources returns the resources for all OSDs or for OSDs of specified device class (hdd, nvme, ssd)
 func GetOSDResources(p ResourceSpec, deviceClass string) v1.ResourceRequirements {
 	if deviceClass == "" {
 		return p[ResourcesKeyOSD]
@@ -80,22 +82,27 @@ func getOSDResourceKeyForDeviceClass(deviceClass string) string {
 	return ResourcesKeyOSD + "-" + deviceClass
 }
 
-// GetPrepareOSDResources returns the placement for the OSDs prepare job
+// GetPrepareOSDResources returns the resources for the OSDs prepare job
 func GetPrepareOSDResources(p ResourceSpec) v1.ResourceRequirements {
 	return p[ResourcesKeyPrepareOSD]
 }
 
-// GetCrashCollectorResources returns the placement for the crash daemon
+// GetCrashCollectorResources returns the resources for the crash daemon
 func GetCrashCollectorResources(p ResourceSpec) v1.ResourceRequirements {
 	return p[ResourcesKeyCrashCollector]
 }
 
-// GetLogCollectorResources returns the placement for the crash daemon
+// GetCmdReporterResources returns the resources for the detect version job
+func GetCmdReporterResources(p ResourceSpec) v1.ResourceRequirements {
+	return p[ResourcesKeyCmdReporter]
+}
+
+// GetLogCollectorResources returns the resources for the crash daemon
 func GetLogCollectorResources(p ResourceSpec) v1.ResourceRequirements {
 	return p[ResourcesKeyLogCollector]
 }
 
-// GetCleanupResources returns the placement for the cleanup job
+// GetCleanupResources returns the resources for the cleanup job
 func GetCleanupResources(p ResourceSpec) v1.ResourceRequirements {
 	return p[ResourcesKeyCleanup]
 }

--- a/pkg/operator/ceph/controller/network.go
+++ b/pkg/operator/ceph/controller/network.go
@@ -252,6 +252,7 @@ func discoverAddressRanges(
 		rookImage,
 		rookImage,
 		clusterSpec.CephVersion.ImagePullPolicy,
+		clusterSpec.Resources,
 	)
 	if err != nil {
 		return ranges, errors.Wrapf(err, "failed to set up ceph %q network canary", cephNetwork)

--- a/pkg/operator/ceph/controller/network_test.go
+++ b/pkg/operator/ceph/controller/network_test.go
@@ -54,9 +54,9 @@ func (m *mockCmdReporter) Run(ctx context.Context, timeout time.Duration) (stdou
 }
 
 // returns a newCmdReporter function that returns the given mockCmdReporter and error
-func mockNewCmdReporter(m *mockCmdReporter, err error) func(clientset kubernetes.Interface, ownerInfo *k8sutil.OwnerInfo, appName string, jobName string, jobNamespace string, cmd []string, args []string, rookImage string, runImage string, imagePullPolicy v1.PullPolicy) (cmdreporter.CmdReporterInterface, error) {
-	return func(clientset kubernetes.Interface, ownerInfo *k8sutil.OwnerInfo, appName, jobName, jobNamespace string, cmd, args []string, rookImage, runImage string, imagePullPolicy v1.PullPolicy) (cmdreporter.CmdReporterInterface, error) {
-		job, err := cmdreporter.MockCmdReporterJob(clientset, ownerInfo, appName, jobName, jobNamespace, cmd, args, rookImage, runImage, imagePullPolicy)
+func mockNewCmdReporter(m *mockCmdReporter, err error) func(clientset kubernetes.Interface, ownerInfo *k8sutil.OwnerInfo, appName string, jobName string, jobNamespace string, cmd []string, args []string, rookImage string, runImage string, imagePullPolicy v1.PullPolicy, resources cephv1.ResourceSpec) (cmdreporter.CmdReporterInterface, error) {
+	return func(clientset kubernetes.Interface, ownerInfo *k8sutil.OwnerInfo, appName, jobName, jobNamespace string, cmd, args []string, rookImage, runImage string, imagePullPolicy v1.PullPolicy, resources cephv1.ResourceSpec) (cmdreporter.CmdReporterInterface, error) {
+		job, err := cmdreporter.MockCmdReporterJob(clientset, ownerInfo, appName, jobName, jobNamespace, cmd, args, rookImage, runImage, imagePullPolicy, resources)
 		if err != nil {
 			// okay to panic here because this is a unit test setup failure, not part of code testing
 			panic(fmt.Sprintf("error setting up mock CmdReporter job: %v", err))

--- a/pkg/operator/ceph/controller/version.go
+++ b/pkg/operator/ceph/controller/version.go
@@ -74,6 +74,7 @@ func DetectCephVersion(ctx context.Context, rookImage, namespace, jobName string
 		rookImage,
 		cephImage,
 		cephClusterSpec.CephVersion.ImagePullPolicy,
+		cephClusterSpec.Resources,
 	)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to set up ceph version job")

--- a/pkg/operator/ceph/csi/controller.go
+++ b/pkg/operator/ceph/csi/controller.go
@@ -256,7 +256,7 @@ func (r *ReconcileCSI) reconcile(request reconcile.Request) (reconcile.Result, e
 	}
 	CustomCSICephConfigExists = exists
 
-	err = r.validateAndConfigureDrivers(serverVersion, ownerInfo)
+	err = r.validateAndConfigureDrivers(serverVersion, ownerInfo, cephClusters.Items[0].Spec.Resources)
 	if err != nil {
 		return opcontroller.ImmediateRetryResult, errors.Wrap(err, "failed to configure ceph csi")
 	}

--- a/pkg/operator/ceph/csi/csi.go
+++ b/pkg/operator/ceph/csi/csi.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"time"
 
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/operator/ceph/cluster/osd/topology"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 
@@ -30,7 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/version"
 )
 
-func (r *ReconcileCSI) validateAndConfigureDrivers(serverVersion *version.Info, ownerInfo *k8sutil.OwnerInfo) error {
+func (r *ReconcileCSI) validateAndConfigureDrivers(serverVersion *version.Info, ownerInfo *k8sutil.OwnerInfo, resources cephv1.ResourceSpec) error {
 	var (
 		v   *CephCSIVersion
 		err error
@@ -45,7 +46,7 @@ func (r *ReconcileCSI) validateAndConfigureDrivers(serverVersion *version.Info, 
 	}
 
 	if !AllowUnsupported && CSIEnabled() {
-		if v, err = r.validateCSIVersion(ownerInfo); err != nil {
+		if v, err = r.validateCSIVersion(ownerInfo, resources); err != nil {
 			return errors.Wrapf(err, "invalid csi version")
 		}
 	} else {

--- a/pkg/operator/ceph/csi/spec.go
+++ b/pkg/operator/ceph/csi/spec.go
@@ -22,6 +22,8 @@ import (
 	"fmt"
 	"time"
 
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+
 	"github.com/rook/rook/pkg/operator/ceph/cluster/telemetry"
 	opcontroller "github.com/rook/rook/pkg/operator/ceph/controller"
 	"github.com/rook/rook/pkg/operator/k8sutil"
@@ -726,7 +728,7 @@ func (r *ReconcileCSI) applyCephClusterNetworkConfig(ctx context.Context, object
 }
 
 // ValidateCSIVersion checks if the configured ceph-csi image is supported
-func (r *ReconcileCSI) validateCSIVersion(ownerInfo *k8sutil.OwnerInfo) (*CephCSIVersion, error) {
+func (r *ReconcileCSI) validateCSIVersion(ownerInfo *k8sutil.OwnerInfo, resources cephv1.ResourceSpec) (*CephCSIVersion, error) {
 	timeout := 15 * time.Minute
 
 	logger.Infof("detecting the ceph csi image version for image %q", CSIParam.CSIPluginImage)
@@ -742,6 +744,7 @@ func (r *ReconcileCSI) validateCSIVersion(ownerInfo *k8sutil.OwnerInfo) (*CephCS
 		r.opConfig.Image,
 		CSIParam.CSIPluginImage,
 		corev1.PullPolicy(CSIParam.ImagePullPolicy),
+		resources,
 	)
 
 	if err != nil {

--- a/pkg/operator/k8sutil/cmdreporter/cmdreporter.go
+++ b/pkg/operator/k8sutil/cmdreporter/cmdreporter.go
@@ -23,6 +23,8 @@ import (
 	"strconv"
 	"time"
 
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+
 	"github.com/coreos/pkg/capnslog"
 	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/daemon/util"
@@ -79,6 +81,7 @@ type cmdReporterCfg struct {
 	rookImage       string
 	runImage        string
 	imagePullPolicy v1.PullPolicy
+	resources       cephv1.ResourceSpec
 }
 
 // New creates a new CmdReporter.
@@ -100,6 +103,7 @@ func New(
 	cmd, args []string,
 	rookImage, runImage string,
 	imagePullPolicy v1.PullPolicy,
+	resources cephv1.ResourceSpec,
 ) (CmdReporterInterface, error) {
 	cfg := &cmdReporterCfg{
 		clientset:       clientset,
@@ -112,6 +116,7 @@ func New(
 		rookImage:       rookImage,
 		runImage:        runImage,
 		imagePullPolicy: imagePullPolicy,
+		resources:       resources,
 	}
 
 	// Validate contents of config struct, not inputs to function to catch any developer errors
@@ -348,6 +353,7 @@ func (cr *cmdReporterCfg) initContainers() []v1.Container {
 		},
 		Image:           cr.rookImage,
 		ImagePullPolicy: cr.imagePullPolicy,
+		Resources:       cephv1.GetCmdReporterResources(cr.resources),
 	}
 	_, copyBinsMount := copyBinariesVolAndMount()
 	c.VolumeMounts = []v1.VolumeMount{copyBinsMount}
@@ -378,6 +384,7 @@ func (cr *cmdReporterCfg) container() (*v1.Container, error) {
 		},
 		Image:           cr.runImage,
 		ImagePullPolicy: cr.imagePullPolicy,
+		Resources:       cephv1.GetCmdReporterResources(cr.resources),
 	}
 	if cr.needToCopyBinaries() {
 		_, copyBinsMount := copyBinariesVolAndMount()
@@ -415,6 +422,7 @@ func MockCmdReporterJob(
 	rookImage string,
 	runImage string,
 	imagePullPolicy v1.PullPolicy,
+	resources cephv1.ResourceSpec,
 ) (*batch.Job, error) {
 	cfg := &cmdReporterCfg{
 		clientset:       clientset,
@@ -427,6 +435,7 @@ func MockCmdReporterJob(
 		rookImage:       rookImage,
 		runImage:        runImage,
 		imagePullPolicy: imagePullPolicy,
+		resources:       resources,
 	}
 	return cfg.initJobSpec()
 }


### PR DESCRIPTION
This is a backport of rook#13653

Prevent Service and ServiceMonitor for rook-ceph-exporter to be
constantly deleted.