### PR TITLE
[CRITEO] Use pod network on ceph-exporter pods

### DIFF
--- a/pkg/operator/ceph/cluster/nodedaemon/exporter.go
+++ b/pkg/operator/ceph/cluster/nodedaemon/exporter.go
@@ -137,7 +137,6 @@ func (r *ReconcileNode) createOrUpdateCephExporter(node corev1.Node, tolerations
 				},
 				Tolerations:                   tolerations,
 				RestartPolicy:                 corev1.RestartPolicyAlways,
-				HostNetwork:                   cephCluster.Spec.Network.IsHost(),
 				Volumes:                       volumes,
 				PriorityClassName:             cephv1.GetCephExporterPriorityClassName(cephCluster.Spec.PriorityClassNames),
 				TerminationGracePeriodSeconds: &terminationGracePeriodSeconds,


### PR DESCRIPTION
This is to prevent port conflicts when having multiple Ceph clusters in the same K8s cluster.
