### PR TITLE
[CRITEO] Add ROOK_DISABLE_OBJECT_STORE_USER and fix ClusterRole prefix

### DIFF
--- a/deploy/charts/library/templates/_cluster-clusterrolebinding.tpl
+++ b/deploy/charts/library/templates/_cluster-clusterrolebinding.tpl
@@ -13,7 +13,7 @@ roleRef:
   name: rook-ceph-mgr-cluster
 subjects:
   - kind: ServiceAccount
-    name: rook-ceph-mgr
+    name: rook-ceph-mgr{{ template "library.suffix-cluster-namespace" . }}
     namespace: {{ .Release.Namespace }} # namespace:cluster
 ---
 # Allow the ceph osd to access cluster-wide resources necessary for determining their topology location
@@ -24,7 +24,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: rook-ceph-osd
+  name: rook-ceph-osd{{ template "library.suffix-cluster-namespace" . }}
 subjects:
   - kind: ServiceAccount
     name: rook-ceph-osd

--- a/deploy/charts/rook-ceph/templates/deployment.yaml
+++ b/deploy/charts/rook-ceph/templates/deployment.yaml
@@ -90,6 +90,8 @@ spec:
           value: "{{ .Values.disableDeviceHotplug }}"
         - name: ROOK_DISCOVER_DEVICES_INTERVAL
           value: "{{ .Values.discoveryDaemonInterval }}"
+        - name: ROOK_DISABLE_OBJECT_STORE_USER
+          value: "{{ .Values.disable_object_store_user }}"
         - name: NODE_NAME
           valueFrom:
             fieldRef:

--- a/deploy/charts/rook-ceph/values.yaml
+++ b/deploy/charts/rook-ceph/values.yaml
@@ -568,6 +568,11 @@ enableDiscoveryDaemon: false
 # -- Set the discovery daemon device discovery interval (default to 60m)
 discoveryDaemonInterval: 60m
 
+# Disables the internal object store user management.
+# Set to 'false' to allow Rook to automatically create and manage
+# Ceph Object Gateway (RGW).
+disable_object_store_user: false
+
 # -- The timeout for ceph commands in seconds
 cephCommandsTimeoutSeconds: "15"
 


### PR DESCRIPTION
This PR introduces a Criteo toggle for Rook's object store user management and resolves naming inconsistency found in the current chart templates.

- Added ROOK_DISABLE_OBJECT_STORE_USER configuration option:
When set to true, this prevents the Rook operator from automatically managing CephObjectStoreUser resources, allowing for external IAM or manual provisioning.

- Resolved a bug in ClusterRoleBinding where the resource name was missing the required prefix
